### PR TITLE
Fix the restarting step if unit not found.

### DIFF
--- a/nodejs/Vagrantfile
+++ b/nodejs/Vagrantfile
@@ -7,6 +7,8 @@ ansible_vars = YAML.load_file('provisioning/vars.yml')
 
 app_name = ansible_vars["nodejs_app_name"]
 
+app_start_script = ansible_vars["nodejs_app_start_script"]
+
 app_directory = ansible_vars["nodejs_app_install_dir"]
 
 # Check for the existence of 'VM_HOST_TCP_PORT' or 'VM_GUEST_TCP_PORT'
@@ -61,8 +63,10 @@ Vagrant.configure(2) do |config|
   end
 
   # http://serverfault.com/a/725051
-  config.vm.provision "shell", inline: "sudo systemctl restart #{app_name}.service",
-    run: "always"
+  if app_start_script.to_s.strip.length != 0
+    config.vm.provision "shell", inline: "sudo systemctl restart #{app_name}.service",
+      run: "always"
+  end
 
   config.vm.provision "shell", inline: "sudo systemctl restart systemd-journal-gatewayd.service",
     run: "always"


### PR DESCRIPTION
'app_name' restart step fails because systemd can't find the unit file if nodejs_app_start_script is [not defined](https://github.com/idi-ops/ansible-nodejs/blob/master/tasks/deploy.yml#L2-L8)
